### PR TITLE
fix: ansible install python-pkg

### DIFF
--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -18,6 +18,7 @@
 ```bash
 sudo apt-get -y update
 sudo apt-get -y install git
+sudo apt install python3-pip
 ```
 
 > Note: If you wish to use ROS 2 Galactic on Ubuntu 20.04, refer to installation instruction from [galactic](https://autowarefoundation.github.io/autoware-documentation/galactic/installation/autoware/source-installation/) branch, but be aware that Galactic version of Autoware might not have latest features.


### PR DESCRIPTION
## Description

- fix ansible install when type `./setup-dev-env.sh`

related to this problem
` {"changed": false, "msg": "Unable to find any of pip3 to use.  pip needs to be installed."} `
https://stackoverflow.com/questions/57729144/ansible-playbook-error-message-unable-to-find-any-of-pip3-to-use-pip-needs-to

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
